### PR TITLE
Add Vendor Name To Version Output

### DIFF
--- a/jdk/make/gensrc/GensrcMisc.gmk
+++ b/jdk/make/gensrc/GensrcMisc.gmk
@@ -30,6 +30,11 @@ include ProfileNames.gmk
 # string and the runtime name into the Version.java file.
 # To be printed by java -version
 
+company_name =
+ifneq ($(COMPANY_NAME),N/A)
+  company_name=($(COMPANY_NAME))
+endif
+
 $(JDK_OUTPUTDIR)/gensrc/sun/misc/Version.java \
 $(PROFILE_VERSION_JAVA_TARGETS): \
     $(JDK_TOPDIR)/src/share/classes/sun/misc/Version.java.template
@@ -41,6 +46,7 @@ $(PROFILE_VERSION_JAVA_TARGETS): \
 	    -e 's/@@java_runtime_version@@/$(FULL_VERSION)/g' \
 	    -e 's/@@java_runtime_name@@/$(RUNTIME_NAME)/g' \
 	    -e 's/@@java_profile_name@@/$(call profile_version_name, $@)/g' \
+	    -e 's/@@company_name@@/$(company_name)/g' \
 	    $< > $@.tmp
 	$(MV) $@.tmp $@
 

--- a/jdk/src/share/classes/sun/misc/Version.java.template
+++ b/jdk/src/share/classes/sun/misc/Version.java.template
@@ -43,6 +43,9 @@ public class Version {
 
     private static final String java_runtime_version =
         "@@java_runtime_version@@";
+        
+    private static final String company_name =
+        "@@company_name@@";
 
     static {
         init();
@@ -103,7 +106,7 @@ public class Version {
 
         /* Second line: runtime version (ie, libraries). */
 
-        ps.print(java_runtime_name + " (build " + java_runtime_version);
+        ps.print(java_runtime_name + " " + company_name + "(build " + java_runtime_version);
 
         if (java_profile_name.length() > 0) {
             // profile name
@@ -120,7 +123,7 @@ public class Version {
         String java_vm_name    = System.getProperty("java.vm.name");
         String java_vm_version = System.getProperty("java.vm.version");
         String java_vm_info    = System.getProperty("java.vm.info");
-        ps.println(java_vm_name + " (build " + java_vm_version + ", " +
+        ps.println(java_vm_name + " " + company_name + "(build " + java_vm_version + ", " +
                    java_vm_info + ")");
     }
 


### PR DESCRIPTION
Vendor name can be set during the build configure step, and this
change adds that vendor name string to the java -version output.

This change already exists in the multiplatform jdk8u repo. This
is the minimal aarch32 port.

Signed-off-by: Adam Farley <adfarley@redhat.com>